### PR TITLE
Install WP rocket fixes and parse:reset

### DIFF
--- a/env/get-latest-wprocket.sh
+++ b/env/get-latest-wprocket.sh
@@ -1,0 +1,2 @@
+LATEST_TAG=$(curl -s https://api.github.com/repos/wp-media/wp-rocket/releases/latest | grep 'tag_name' | cut -d\" -f4)
+wp plugin install https://github.com/wp-media/wp-rocket/archive/refs/tags/$LATEST_TAG.zip --force

--- a/env/parse-wp-rocket.sh
+++ b/env/parse-wp-rocket.sh
@@ -1,1 +1,1 @@
-wp parser create wp-content/wp-rocket/inc/ --user=admin
+wp parser create wp-content/plugins/wp-rocket/inc/ --user=admin

--- a/env/reset.sh
+++ b/env/reset.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Delete (force) all posts created by PHPdoc parse.
+wp post delete --force $(wp post list --post_type='blocks-handbook' --format=ids)
+wp post delete --force $(wp post list --post_type='wpcs-handbook' --format=ids)
+wp post delete --force $(wp post list --post_type='rest-api-handbook' --format=ids)
+wp post delete --force $(wp post list --post_type='adv-admin-handbook' --format=ids)
+wp post delete --force $(wp post list --post_type='wp-parser-function' --format=ids)
+wp post delete --force $(wp post list --post_type='wp-parser-class' --format=ids)
+wp post delete --force $(wp post list --post_type='wp-parser-hook' --format=ids)
+wp post delete --force $(wp post list --post_type='wp-parser-method' --format=ids)
+wp post delete --force $(wp post list --post_type='command' --format=ids)
+
+# Delete all terms created by PHPdoc parse.
+wp term list 'wp-parser-package' --field=term_id | xargs wp term delete 'wp-parser-package'
+wp term list 'wp-parser-since' --field=term_id | xargs wp term delete 'wp-parser-since'
+wp term list 'wp-parser-namespace' --field=term_id | xargs wp term delete 'wp-parser-namespace'
+wp term list 'wp-parser-source-file' --field=term_id | xargs wp term delete 'wp-parser-source-file'

--- a/get-latest-wprocket.sh
+++ b/get-latest-wprocket.sh
@@ -1,7 +1,0 @@
-# Checkout WP Rocket repository
-cd ./source/wp-content
-
-LATEST_TAG=$(curl -s https://api.github.com/repos/wp-media/wp-rocket/releases/latest | grep 'tag_name' | cut -d\" -f4)
-git clone https://github.com/wp-media/wp-rocket.git
-cd wp-rocket
-git checkout tags/$LATEST_TAG

--- a/package.json
+++ b/package.json
@@ -13,16 +13,17 @@
 	},
 	"scripts": {
 		"setup:tools": "yarn && composer install && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser install",
-		"setup": "yarn setup:wp && yarn parse",
+		"setup": "yarn setup:wp",
 		"setup:wp": "wp-env run cli bash env/setup.sh",
-		"parse": "wp-env run cli bash env/parse-wp-rocket.sh",
+		"parse": "yarn update:wprocket && wp-env run cli bash env/parse-wp-rocket.sh",
 		"update:tools": "composer update && TEXTDOMAIN=wporg composer exec update-configs && composer --working-dir=./source/wp-content/plugins/phpdoc-parser update",
 		"wp-env": "wp-env",
 		"build": "yarn workspaces run build",
 		"build:theme": "yarn workspace wporg-developer-2023 build",
 		"start:theme": "yarn workspace wporg-developer-2023 start",
 		"lint:css": "wp-scripts lint-style",
-		"update:wprocket": "bash get-latest-wprocket.sh"
+		"update:wprocket": "wp-env run cli bash env/get-latest-wprocket.sh",
+		"parse:reset": "wp-env run cli bash env/reset.sh"
 	},
 	"workspaces": [
 		"source/wp-content/themes/wporg-developer-2023"


### PR DESCRIPTION
- Change: Install WP Rocket with zip (not enabled) instead of Git/clone/checkout.
- New: parse:reset script
- Fix: Path to WP Rocket `wp-content/plugins/wp-rocket`